### PR TITLE
Fixes bug #1039

### DIFF
--- a/src/extensions/mobile/bootstrap-table-mobile.js
+++ b/src/extensions/mobile/bootstrap-table-mobile.js
@@ -53,6 +53,19 @@
         that.toggleView();
     };
 
+    var debounce = function(func,wait) {
+        var timeout;
+        return function() {
+            var context = this, args = arguments;
+            var later = function() {
+                timeout = null;
+                func.apply(context,args);
+            };
+            clearTimeout(timeout);
+            timeout = setTimeout(later,wait);
+        };
+    };
+
     $.extend($.fn.bootstrapTable.defaults, {
         mobileResponsive: false,
         minWidth: 562,
@@ -75,13 +88,21 @@
             return;
         }
 
-        var that = this;
-        $(window).resize(function () {
-            changeView(that, $(this).width(), $(this).height())
-        });
+        var that = this, old = { w: $(window).width(), h: $(window).height() };
+
+        $(window).on('resize orientationchange',debounce(function (evt) {
+            // reset view if height has only changed by at least the threshold.
+            var h = $(this).height(), w = $(this).width();
+            if (Math.abs(old.h - h) > that.options.heightThreshold || old.w != w) {
+                changeView(that, w, h);
+                old = { w: w, h: h };
+            }
+        },200));
 
         if (this.options.checkOnInit) {
-            changeView(this, $(window).width(), $(window).height());
+            var h = $(window).height(), w = $(window).width();
+            changeView(this, w, h);
+            old = { w: w, h: h };
         }
     };
 }(jQuery);


### PR DESCRIPTION
Adds new option to extension/mobile for  `heightThreshold` (defaults to `100px`), which helps prevent mobile chroime (webkit) auto-hiding toolbar from causing tableView to switch back to cardView when scrolling up or down in the broswer window (if the user has switched to tableView on a small screen).

As a side effect, this also debounces the window resize event.  Also included `orientationchange` listener.
